### PR TITLE
feat: Add Docker image and self-hosting instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/*
+!embed_fixer/**/*
+!l10n/**/*
+!pyproject.toml
+!run.py
+!uv.lock

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,49 @@
+name: Docker Build
+
+permissions:
+  packages: write
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=${{ github.workflow }}
+          cache-to: type=gha,mode=max,scope=${{ github.workflow }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# First, build the application in the `/app` directory.
+FROM ghcr.io/astral-sh/uv:python3.12-alpine AS builder
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+WORKDIR /app
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --frozen --no-install-project --no-dev
+ADD . /app
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev
+
+# Then, use a final image without uv
+FROM python:3.12-alpine
+
+WORKDIR /app
+
+# Copy the application from the builder
+COPY --from=builder --chown=app:app /app /app
+
+# Place executables in the environment at the front of the path, set env var defaults
+ENV PATH="/app/.venv/bin:$PATH" ENV=prod DB_URI=sqlite:///data/embed_fixer.db
+
+VOLUME [ "/data", "/app/logs" ]
+
+CMD ["python", "run.py"]

--- a/README.md
+++ b/README.md
@@ -104,3 +104,16 @@ docker run -v /my/mnt/logs:/app/logs -v /my/mnt/data:/data -e DISCORD_TOKEN=Your
 
 - `DISCORD_TOKEN`: your Discord bot token
 - `DB_URI`: defaults to `sqlite:///data/embed_fixer.db`, available to customize the database location
+
+## Local
+
+1. Install [uv](https://docs.astral.sh/uv/getting-started/installation/)
+1. Clone the repository
+1. Create a `.env` file:
+
+   ```env
+   DISCORD_TOKEN=YourDiscordBotToken.Example.SomeExampleBase64Junk
+   ENV=dev
+   ```
+
+1. `uv run run.py`

--- a/README.md
+++ b/README.md
@@ -80,3 +80,27 @@ Below are settings you can change with the `/settings` command:
 
 Whether you want a new fix to be added, to request a new feature, to report a bug, or to contribute to translations. You can do so by creating an issue or a pull request.  
 If GitHub is not your type, you can find me on [Discord](https://discord.com/invite/b22kMKuwbS), my username is @seria_ati.
+
+# Self Hosting
+
+1. Create a [Discord application](https://discord.com/developers/applications)
+1. On the **Bot** page, generate a token and save it for later
+1. Enable **Message Content Intent**
+1. Run the application with your bot token as the `DISCORD_TOKEN` environment variable
+1. Invite your bot with the invite link in the logs
+
+## Docker
+
+```sh
+docker run -v /my/mnt/logs:/app/logs -v /my/mnt/data:/data -e DISCORD_TOKEN=YourDiscordBotToken.Example.SomeExampleBase64Junk ghcr.io/seriaati/embed-fixer:latest
+```
+
+### Volumes
+
+- `/app/logs`: the logfiles produced by the program
+- `/data`: the default location for the `embed_fixer.db` SQLite database file
+
+### Environment Variables
+
+- `DISCORD_TOKEN`: your Discord bot token
+- `DB_URI`: defaults to `sqlite:///data/embed_fixer.db`, available to customize the database location

--- a/embed_fixer/bot.py
+++ b/embed_fixer/bot.py
@@ -26,6 +26,15 @@ intents = discord.Intents(
     guilds=True, emojis=True, messages=True, message_content=True, reactions=True
 )
 allowed_mentions = discord.AllowedMentions(everyone=False)
+permissions = discord.Permissions(
+    manage_webhooks=True,
+    view_channel=True,
+    send_messages=True,
+    send_messages_in_threads=True,
+    manage_messages=True,
+    embed_links=True,
+    add_reactions=True,
+)
 
 
 class EmbedFixer(commands.AutoShardedBot):
@@ -59,6 +68,8 @@ class EmbedFixer(commands.AutoShardedBot):
 
         await self.translator.load()
         await self.tree.set_translator(AppCommandTranslator(self.translator))
+
+        logger.info(f"Invite: {discord.utils.oauth_url(self.user.id, permissions=permissions)}")
 
         await Tortoise.init(
             {


### PR DESCRIPTION
Hey, I love this project, but some may find it risky adding a bot with message content permissions. Here are some changes that make self hosting the bot a little easier.

- Build and distribute Docker image via GitHub registry
  - Built according to [uv Docker best practices](https://github.com/astral-sh/uv-docker-example/blob/main/multistage.Dockerfile)
  - Image is built on push to main
  - You can see my fork for an example of the published image
- Add an invite URL to the logs
  - Makes it easier than finding your client ID and permissions integer and assembling it manually
- Docs for getting started, whether it's Docker, or just local CLI