### PR TITLE
fix: Undo Docker tag update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev
 
 # Then, use a final image without uv
-FROM python:3.13-alpine
+FROM python:3.12-alpine
 
 WORKDIR /app
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>seriaati/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "description": "Disable Dockerfile tag updates",
+      "matchFileNames": [
+        "Dockerfile"
+      ],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
In #63, Renovate updated the Python Docker base image tag to 3.13, which broke the image.

This rolls back the tag update, and disables Renovate for the Dockerfile.