### PR TITLE
Remove ddinstagram (no longer working)

### DIFF
--- a/embed_fixer/fixes.py
+++ b/embed_fixer/fixes.py
@@ -199,13 +199,6 @@ DOMAINS: Final[list[Domain]] = [
         ],
         fix_methods=[
             FixMethod(
-                id=8,
-                name="InstaFix",
-                fixes=[ReplaceFix(old_domain="instagram.com", new_domain="ddinstagram.com")],
-                repo_url="https://github.com/Wikidepia/InstaFix",
-                default=True,
-            ),
-            FixMethod(
                 id=9,
                 name=EMBEDEZ_NAME,
                 fixes=[ReplaceFix(old_domain="instagram.com", new_domain="g.embedez.com")],
@@ -215,6 +208,7 @@ DOMAINS: Final[list[Domain]] = [
                 id=23,
                 name="KKInstagram",
                 fixes=[ReplaceFix(old_domain="instagram.com", new_domain="kkinstagram.com")],
+                default=True,
             ),
         ],
     ),


### PR DESCRIPTION
InstaFix ddinstagram is no longer working. repo last update is 8+ months ago.
https://github.com/Wikidepia/InstaFix/issues/181

Replaced default with kkinstagram