### PR TITLE
feat(threads): Add FixEmbed as fix service

### DIFF
--- a/embed_fixer/fixes.py
+++ b/embed_fixer/fixes.py
@@ -431,6 +431,12 @@ DOMAINS: Final[list[Domain]] = [
                 repo_url=EMBEDEZ_REPO_URL,
                 has_ads=True,
             ),
+            FixMethod(
+                id=33,
+                name="FixEmbed",
+                fixes=[AppendURLFix(domain="fixembed.app/embed")],
+                repo_url="https://fixembed.app",
+            ),
         ],
     ),
     Domain(


### PR DESCRIPTION
## Summary

- Adds [FixEmbed](https://fixembed.app) as a new fix method for the Threads domain (id=33).
- Uses the existing `AppendURLFix` mechanism, producing `https://fixembed.app/embed?url=<original-url>`.
- Not set as default — `FixThreads` remains the default; users can opt in via `/settings`.

## Test plan

- [x] Built locally and ran the bot in a test guild.
- [x] Switched the Threads fix service to `FixEmbed` via `/settings`.
- [x] Posted a `https://www.threads.com/...` link and confirmed the bot replaces it with `https://fixembed.app/embed?url=...` and the embed renders correctly.
- [x] Verified existing fix methods (FixThreads, vxThreads, EmbedEZ) still work after the change.