### PR TITLE
feat(pixiv): convert ugoira to mp4 instead of gif

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Then, use a final image without uv
 FROM python:3.12-slim-bookworm
 
-# Install curl for healthcheck
-RUN apt-get update && apt-get install -y --no-install-recommends curl \
+# Install curl for healthcheck and ffmpeg for pixiv ugoira (animation) conversion
+RUN apt-get update && apt-get install -y --no-install-recommends curl ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/embed_fixer/cogs/fixer.py
+++ b/embed_fixer/cogs/fixer.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import io
 from typing import TYPE_CHECKING, Any, Final, Literal, cast
 from urllib.parse import parse_qs, urlparse, urlunparse
 
@@ -37,6 +36,7 @@ if TYPE_CHECKING:
 
     from embed_fixer.bot import EmbedFixer, Interaction
     from embed_fixer.fixes import Domain, FixMethod, ReplaceFix, Website
+    from embed_fixer.utils.fetch_info import UgoiraMeta
 
 USERNAME_SUFFIX: Final[str] = " (Embed Fixer)"
 ERROR_MSG_DELETE_AFTER: Final[int] = 10
@@ -458,6 +458,7 @@ class FixerCog(commands.Cog):
         info = None
         headers = None
         proxy = None
+        ugoira_meta: UgoiraMeta | None = None
 
         try:
             if domain_id is DomainId.PIXIV:
@@ -466,24 +467,11 @@ class FixerCog(commands.Cog):
                     return PostExtractionResult(medias=[], content="", author_md="")
 
                 content = info.description
-
-                if info.is_ugoira and info.ugoira_meta:
-                    gif_bytes = await self.fetch_info.ugoira_to_gif(info.ugoira_meta)
-                    if gif_bytes is None:
-                        return PostExtractionResult(medias=[], content="", author_md="")
-
-                    file = discord.File(
-                        io.BytesIO(gif_bytes), filename="ugoira.gif", spoiler=spoiler
-                    )
-                    return PostExtractionResult(
-                        medias=[Media(url=url, file=file)],
-                        content=content[:2000],
-                        author_md=info.author_md,
-                    )
-
                 media_urls = info.image_urls
                 headers = settings.pixiv_headers
                 proxy = settings.proxy_url
+                if info.is_ugoira:
+                    ugoira_meta = info.ugoira_meta
             elif domain_id is DomainId.TWITTER:
                 info = await self.fetch_info.twitter(url)
                 content = "" if info is None else info.text
@@ -503,11 +491,18 @@ class FixerCog(commands.Cog):
         logger.debug(f"Extracted media URLs: {media_urls}")
 
         downloader = MediaDownloader(
-            self.bot.session, media_urls=media_urls, headers=headers, proxy=proxy
+            self.bot.session,
+            media_urls=media_urls,
+            headers=headers,
+            proxy=proxy,
+            ugoira_meta=ugoira_meta,
         )
         await downloader.start(spoiler=spoiler, filesize_limit=filesize_limit)
 
         medias: list[Media] = []
+
+        if downloader.ugoira_file is not None:
+            medias.append(Media(url=url, file=downloader.ugoira_file))
 
         for media_url in media_urls:
             file_ = downloader.files.get(media_url)

--- a/embed_fixer/utils/download_media.py
+++ b/embed_fixer/utils/download_media.py
@@ -2,14 +2,20 @@ from __future__ import annotations
 
 import asyncio
 import io
+import pathlib
+import tempfile
+import zipfile
 from typing import TYPE_CHECKING
 
 import aiohttp
 import discord
+import ffmpeg
 from loguru import logger
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+    from embed_fixer.utils.fetch_info import UgoiraFrame, UgoiraMeta
 
 
 class MediaDownloader:
@@ -20,12 +26,97 @@ class MediaDownloader:
         media_urls: Sequence[str],
         headers: dict[str, str] | None = None,
         proxy: str | None = None,
+        ugoira_meta: UgoiraMeta | None = None,
     ) -> None:
         self.media_urls = media_urls
         self.session = session
         self.headers = headers or {}
         self.files: dict[str, discord.File] = {}
         self.proxy = proxy
+        self.ugoira_meta = ugoira_meta
+        self.ugoira_file: discord.File | None = None
+
+    async def _fetch_bytes(self, url: str) -> bytes | None:
+        timeout = aiohttp.ClientTimeout(total=30)
+        try:
+            async with self.session.get(
+                url, timeout=timeout, headers=self.headers, proxy=self.proxy
+            ) as resp:
+                if resp.status != 200:
+                    logger.warning(f"Failed to fetch {url}, status: {resp.status}")
+                    return None
+                return await resp.read()
+        except Exception:
+            logger.exception(f"Failed to fetch bytes from {url}")
+            return None
+
+    @staticmethod
+    def _zip_to_mp4(zip_bytes: bytes, frames: Sequence[UgoiraFrame]) -> bytes | None:
+        """Convert an ugoira frame ZIP into an MP4, returning its bytes (or None on failure)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = pathlib.Path(tmp)
+            with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+                zf.extractall(tmp_dir)
+
+            # ffmpeg concat demuxer: each frame held for its delay, last frame repeated so
+            # its duration is honored.
+            concat_path = tmp_dir / "concat.txt"
+            lines = [
+                f"file '{tmp_dir / frame.file}'\nduration {frame.delay / 1000}\n"
+                for frame in frames
+            ]
+            lines.append(f"file '{tmp_dir / frames[-1].file}'\n")
+            concat_path.write_text("".join(lines), encoding="utf-8")
+
+            output_path = tmp_dir / "output.mp4"
+            try:
+                (
+                    ffmpeg.input(str(concat_path), format="concat", safe=0)
+                    .output(
+                        str(output_path),
+                        vcodec="libx264",
+                        pix_fmt="yuv420p",
+                        movflags="faststart",
+                        # libx264 + yuv420p requires even dimensions; round down to nearest even.
+                        vf="scale=trunc(iw/2)*2:trunc(ih/2)*2",
+                    )
+                    .global_args("-an")
+                    .overwrite_output()
+                    .run(quiet=True)
+                )
+            except ffmpeg.Error as e:
+                logger.error(f"ffmpeg failed to convert ugoira: {e.stderr}")
+                return None
+            except Exception:
+                # e.g. the ffmpeg binary is not installed; degrade instead of crashing.
+                logger.exception("Failed to convert ugoira to MP4")
+                return None
+
+            return output_path.read_bytes()
+
+    async def _download_ugoira(
+        self, meta: UgoiraMeta, *, spoiler: bool, filesize_limit: int
+    ) -> None:
+        """Download an ugoira ZIP and convert it to MP4, preferring the higher resolution.
+
+        Tries the original-resolution ZIP first; if it is unavailable or its MP4 exceeds the
+        upload limit, falls back to the smaller 600x600 source.
+        """
+        loop = asyncio.get_running_loop()
+        for label, src in (("originalSrc", meta.original_src), ("src", meta.src)):
+            zip_bytes = await self._fetch_bytes(src)
+            if zip_bytes is None:
+                continue
+
+            mp4_bytes = await loop.run_in_executor(None, self._zip_to_mp4, zip_bytes, meta.frames)
+            if mp4_bytes is not None and len(mp4_bytes) <= filesize_limit:
+                logger.debug(f"Using ugoira source: {label}")
+                self.ugoira_file = discord.File(
+                    io.BytesIO(mp4_bytes), filename="ugoira.mp4", spoiler=spoiler
+                )
+                return
+
+        logger.warning("Failed to produce an ugoira MP4 within the filesize limit")
 
     async def _download(self, url: str, *, spoiler: bool, filesize_limit: int) -> None:
         timeout = aiohttp.ClientTimeout(total=10)
@@ -63,4 +154,10 @@ class MediaDownloader:
             for media_url in self.media_urls:
                 tg.create_task(
                     self._download(media_url, spoiler=spoiler, filesize_limit=filesize_limit)
+                )
+            if self.ugoira_meta is not None:
+                tg.create_task(
+                    self._download_ugoira(
+                        self.ugoira_meta, spoiler=spoiler, filesize_limit=filesize_limit
+                    )
                 )

--- a/embed_fixer/utils/download_media.py
+++ b/embed_fixer/utils/download_media.py
@@ -53,6 +53,10 @@ class MediaDownloader:
     @staticmethod
     def _zip_to_mp4(zip_bytes: bytes, frames: Sequence[UgoiraFrame]) -> bytes | None:
         """Convert an ugoira frame ZIP into an MP4, returning its bytes (or None on failure)."""
+        if not frames:
+            logger.warning("No ugoira frames to convert")
+            return None
+
         with tempfile.TemporaryDirectory() as tmp:
             tmp_dir = pathlib.Path(tmp)
             with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:

--- a/embed_fixer/utils/fetch_info.py
+++ b/embed_fixer/utils/fetch_info.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import datetime
-import io
 import re
-import zipfile
 from typing import TYPE_CHECKING, Any, Final
 
 from dotenv import load_dotenv
 from loguru import logger
-from PIL import Image
 from pydantic import BaseModel, Field, field_validator
 
 from embed_fixer.core.config import settings
@@ -118,43 +115,6 @@ class PostInfoFetcher:
             return False
         return PIXIV_R18_TAG in artwork_info.tags
 
-    async def ugoira_to_gif(self, meta: UgoiraMeta) -> bytes | None:
-
-        async with self.session.get(
-            meta.original_src, headers=settings.pixiv_headers, proxy=settings.proxy_url
-        ) as response:
-            if response.status != 200:
-                logger.warning(f"Failed to fetch ugoira ZIP: {response.status}")
-                return None
-            zip_bytes = await response.read()
-
-        frames: list[Image.Image] = []
-        durations: list[int] = []
-        try:
-            with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
-                for frame in meta.frames:
-                    img = Image.open(io.BytesIO(zf.read(frame.file))).convert("RGBA")
-                    frames.append(img)
-                    durations.append(frame.delay)
-
-            if not frames:
-                return None
-
-            output = io.BytesIO()
-            frames[0].save(
-                output,
-                format="GIF",
-                save_all=True,
-                append_images=frames[1:],
-                duration=durations,
-                loop=0,
-                optimize=False,
-            )
-            return output.getvalue()
-        finally:
-            for img in frames:
-                img.close()
-
     async def twitter_is_nsfw(self, url: str) -> bool:
         info = await self.twitter(url)
         if info is None:
@@ -239,6 +199,7 @@ class UgoiraFrame(BaseModel):
 
 
 class UgoiraMeta(BaseModel):
+    src: str  # 600x600 ZIP, used as a fallback when the original is too large
     original_src: str = Field(alias="originalSrc")
     mime_type: str
     frames: list[UgoiraFrame]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "pydantic-settings>=2.11.0",
   "anyio>=4.12.1",
   "pillow>=11.0.0",
+  "ffmpeg-python>=0.2.0",
 ]
 description = "Discord bot that fixes social media embeds"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -386,6 +386,7 @@ dependencies = [
     { name = "anyio" },
     { name = "discord-py" },
     { name = "emoji" },
+    { name = "ffmpeg-python" },
     { name = "iso639-lang" },
     { name = "jishaku" },
     { name = "loguru" },
@@ -420,6 +421,7 @@ requires-dist = [
     { name = "asyncpg", marker = "extra == 'asyncpg'", specifier = ">=0.31.0" },
     { name = "discord-py", specifier = ">=2.4.0" },
     { name = "emoji", specifier = ">=2.15.0" },
+    { name = "ffmpeg-python", specifier = ">=0.2.0" },
     { name = "iso639-lang", specifier = ">=2.6.3" },
     { name = "jishaku", specifier = ">=2.5.2" },
     { name = "loguru", specifier = ">=0.7.2" },
@@ -446,6 +448,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/78/0d2db9382c92a163d7095fc08efff7800880f830a152cfced40161e7638d/emoji-2.15.0.tar.gz", hash = "sha256:eae4ab7d86456a70a00a985125a03263a5eac54cd55e51d7e184b1ed3b6757e4", size = 615483, upload-time = "2025-09-21T12:13:02.755Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/5e/4b5aaaabddfacfe36ba7768817bd1f71a7a810a43705e531f3ae4c690767/emoji-2.15.0-py3-none-any.whl", hash = "sha256:205296793d66a89d88af4688fa57fd6496732eb48917a87175a023c8138995eb", size = 608433, upload-time = "2025-09-21T12:13:01.197Z" },
+]
+
+[[package]]
+name = "ffmpeg-python"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "future" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/5e/d5f9105d59c1325759d838af4e973695081fbbc97182baf73afc78dec266/ffmpeg-python-0.2.0.tar.gz", hash = "sha256:65225db34627c578ef0e11c8b1eb528bb35e024752f6f10b78c011f6f64c4127", size = 21543, upload-time = "2019-07-06T00:19:08.989Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl", hash = "sha256:ac441a0404e053f8b6a1113a77c0f452f1cfc62f6344a769475ffdc0f56c23c5", size = 25024, upload-time = "2019-07-06T00:19:07.215Z" },
 ]
 
 [[package]]
@@ -551,6 +565,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "future"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/b2/4140c69c6a66432916b26158687e821ba631a4c9273c474343badf84d3ba/future-1.0.0.tar.gz", hash = "sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05", size = 1228490, upload-time = "2024-02-21T11:52:38.461Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/71/ae30dadffc90b9006d77af76b393cb9dfbfc9629f339fc1574a1c52e6806/future-1.0.0-py3-none-any.whl", hash = "sha256:929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216", size = 491326, upload-time = "2024-02-21T11:52:35.956Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fetching the ugoira animation at original resolution produced files too large to upload, so animated pixiv posts failed to embed when extracting media. Convert the ugoira frame ZIP to an MP4, which is far smaller than the old GIF, using ffmpeg. The original resolution is preferred, falling back to the 600x600 source when the original MP4 exceeds the upload limit.

- scale to even dimensions so `libx264`/`yuv420p` does not reject odd-sized frames
- degrade gracefully when the `ffmpeg` binary is missing or conversion fails
- install `ffmpeg` in the runtime image

Normal channels are unchanged: pixiv links remain a plain `phixiv.net` URL swap, which already embeds ugoira as a video. The conversion only applies to the media-extraction path.